### PR TITLE
V2.1 update @react-ui config for publishing UI lib

### DIFF
--- a/apps/frontend/tsconfig.json
+++ b/apps/frontend/tsconfig.json
@@ -6,7 +6,7 @@
     "lib": ["ES2020", "DOM", "DOM.Iterable"],
     "module": "ESNext",
     "skipLibCheck": true,
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "allowSyntheticDefaultImports": true,
     "resolveJsonModule": true,
     "isolatedModules": true,

--- a/packages/@react-ui/.gitignore
+++ b/packages/@react-ui/.gitignore
@@ -1,0 +1,17 @@
+# Build outputs
+dist/
+build/
+
+# Dependencies
+node_modules/
+
+# TypeScript
+*.tsbuildinfo
+
+# IDE
+.vscode/
+.idea/
+
+# OS
+.DS_Store
+Thumbs.db 

--- a/packages/@react-ui/README.md
+++ b/packages/@react-ui/README.md
@@ -1,0 +1,45 @@
+# @react-ui
+
+A React UI component library built with TypeScript and Tailwind CSS.
+
+## Installation
+
+```bash
+pnpm add github:ge-m-zhang/ReactNest-template#main
+```
+
+## Usage
+
+```tsx
+import { Button, Alert, Badge, Box } from '@react-ui';
+
+function App() {
+  return (
+    <div>
+      <Button variant="contained" color="primary">
+        Click me
+      </Button>
+
+      <Alert variant="success">This is a success message</Alert>
+
+      <Badge variant="primary">New</Badge>
+
+      <Box padding="md" background="gray" rounded="lg">
+        Content here
+      </Box>
+    </div>
+  );
+}
+```
+
+## Available Components
+
+- **Button** - Multiple variants, sizes, and colors
+- **Alert** - Success, error, warning, and info variants
+- **Badge** - Color-coded badges
+- **Box** - Flexible layout component
+- **ThemeProvider** - Dark/light mode support
+
+## License
+
+MIT

--- a/packages/@react-ui/README.md
+++ b/packages/@react-ui/README.md
@@ -1,17 +1,17 @@
-# @react-ui
+# @gmz/react-ui
 
 A React UI component library built with TypeScript and Tailwind CSS.
 
 ## Installation
 
 ```bash
-pnpm add github:ge-m-zhang/ReactNest-template#main
+npm install @gmz/react-ui
 ```
 
 ## Usage
 
 ```tsx
-import { Button, Alert, Badge, Box } from '@react-ui';
+import { Button, Alert, Badge, Box } from '@gmz/react-ui';
 
 function App() {
   return (
@@ -39,6 +39,24 @@ function App() {
 - **Badge** - Color-coded badges
 - **Box** - Flexible layout component
 - **ThemeProvider** - Dark/light mode support
+
+## Development
+
+This package is built with TypeScript and uses the following key dependencies:
+
+- `class-variance-authority` - For component variant management
+- `clsx` - For conditional className handling
+- `tailwind-merge` - For Tailwind CSS class merging
+
+## Scripts
+
+This project uses pnpm as the package manager. Available scripts:
+
+- `pnpm build` - Build the package
+- `pnpm dev` - Watch mode for development
+- `pnpm lint` - Run ESLint
+- `pnpm typecheck` - Type checking without emission
+- `pnpm clean` - Clean the dist directory
 
 ## License
 

--- a/packages/@react-ui/package.json
+++ b/packages/@react-ui/package.json
@@ -1,8 +1,8 @@
 {
   "name": "@gmz/react-ui",
   "version": "0.1.0",
-  "main": "./dist/index.js",
-  "types": "./dist/index.d.ts",
+  "main": "./dist/index.cjs",
+  "module": "./dist/index.js",
   "repository": {
     "type": "git",
     "url": "https://github.com/ge-m-zhang/ReactNest-template.git",
@@ -15,20 +15,23 @@
     ".": {
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js",
-      "require": "./dist/index.js"
+      "require": "./dist/index.cjs"
     },
     "./lib/*": {
       "types": "./dist/lib/*",
       "import": "./dist/lib/*",
-      "require": "./dist/lib/*"
+      "require": "./dist/lib/*.cjs"
     }
   },
   "scripts": {
-    "build": "tsc",
+    "build": "npm run build:esm && npm run build:cjs && npm run fix:cjs",
+    "build:esm": "tsc --project tsconfig.esm.json",
+    "build:cjs": "tsc --project tsconfig.cjs.json",
+    "fix:cjs": "node scripts/fix-cjs-extensions.js",
     "dev": "tsc --watch",
     "lint": "eslint \"**/*.ts*\"",
     "typecheck": "tsc --noEmit",
-    "clean": "rm -rf dist"
+    "clean": "rm -rf dist dist-cjs"
   },
   "dependencies": {
     "class-variance-authority": "^0.7.0",

--- a/packages/@react-ui/package.json
+++ b/packages/@react-ui/package.json
@@ -1,12 +1,15 @@
 {
-  "name": "@react-ui",
-  "version": "0.1",
+  "name": "@gmz/react-ui",
+  "version": "0.1.0",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/ge-m-zhang/ReactNest-template.git",
+    "url": "https://github.com/ge-m-zhang/ReactNest-template.git",
     "directory": "packages/@react-ui"
+  },
+  "publishConfig": {
+    "access": "public"
   },
   "exports": {
     ".": {

--- a/packages/@react-ui/package.json
+++ b/packages/@react-ui/package.json
@@ -1,24 +1,31 @@
 {
   "name": "@react-ui",
-  "version": "0.0.1",
-  "private": true,
-  "main": "./src/index.ts",
-  "types": "./src/index.ts",
+  "version": "0.1",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/ge-m-zhang/ReactNest-template.git",
+    "directory": "packages/@react-ui"
+  },
   "exports": {
     ".": {
-      "types": "./src/index.ts",
-      "import": "./src/index.ts",
-      "require": "./src/index.ts"
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "require": "./dist/index.js"
     },
     "./lib/*": {
-      "types": "./src/lib/*",
-      "import": "./src/lib/*",
-      "require": "./src/lib/*"
+      "types": "./dist/lib/*",
+      "import": "./dist/lib/*",
+      "require": "./dist/lib/*"
     }
   },
   "scripts": {
+    "build": "tsc",
+    "dev": "tsc --watch",
     "lint": "eslint \"**/*.ts*\"",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "clean": "rm -rf dist"
   },
   "dependencies": {
     "class-variance-authority": "^0.7.0",
@@ -34,5 +41,9 @@
   },
   "peerDependencies": {
     "react": "^18.2.0"
-  }
+  },
+  "files": [
+    "dist/**/*",
+    "README.md"
+  ]
 }

--- a/packages/@react-ui/package.json
+++ b/packages/@react-ui/package.json
@@ -3,6 +3,7 @@
   "version": "0.1.0",
   "main": "./dist/index.cjs",
   "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
   "repository": {
     "type": "git",
     "url": "https://github.com/ge-m-zhang/ReactNest-template.git",
@@ -19,8 +20,7 @@
     },
     "./lib/*": {
       "types": "./dist/lib/*",
-      "import": "./dist/lib/*",
-      "require": "./dist/lib/*.cjs"
+      "import": "./dist/lib/*"
     }
   },
   "scripts": {

--- a/packages/@react-ui/scripts/fix-cjs-extensions.js
+++ b/packages/@react-ui/scripts/fix-cjs-extensions.js
@@ -1,0 +1,29 @@
+const fs = require('fs');
+const path = require('path');
+
+// Simply copy .js files from dist-cjs to dist as .cjs files
+const distCjs = './dist-cjs';
+const dist = './dist';
+
+function copyWithExtension(src, dest, oldExt, newExt) {
+  if (!fs.existsSync(src)) return;
+
+  const files = fs.readdirSync(src, { withFileTypes: true });
+
+  files.forEach((file) => {
+    if (file.isDirectory()) {
+      const srcDir = path.join(src, file.name);
+      const destDir = path.join(dest, file.name);
+      fs.mkdirSync(destDir, { recursive: true });
+      copyWithExtension(srcDir, destDir, oldExt, newExt);
+    } else if (file.name.endsWith(oldExt)) {
+      const srcFile = path.join(src, file.name);
+      const destFile = path.join(dest, file.name.replace(oldExt, newExt));
+      fs.copyFileSync(srcFile, destFile);
+    }
+  });
+}
+
+copyWithExtension(distCjs, dist, '.js', '.cjs');
+fs.rmSync(distCjs, { recursive: true, force: true });
+console.log('CommonJS files renamed to .cjs');

--- a/packages/@react-ui/scripts/fix-cjs-extensions.js
+++ b/packages/@react-ui/scripts/fix-cjs-extensions.js
@@ -25,5 +25,7 @@ function copyWithExtension(src, dest, oldExt, newExt) {
 }
 
 copyWithExtension(distCjs, dist, '.js', '.cjs');
-fs.rmSync(distCjs, { recursive: true, force: true });
+if (fs.existsSync(distCjs)) {
+  fs.rmSync(distCjs, { recursive: true, force: true });
+}
 console.log('CommonJS files renamed to .cjs');

--- a/packages/@react-ui/tsconfig.cjs.json
+++ b/packages/@react-ui/tsconfig.cjs.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "module": "CommonJS",
+    "outDir": "./dist-cjs",
+    "declaration": false
+  }
+}

--- a/packages/@react-ui/tsconfig.esm.json
+++ b/packages/@react-ui/tsconfig.esm.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "module": "ESNext",
+    "outDir": "./dist",
+    "declaration": true
+  }
+}

--- a/packages/@react-ui/tsconfig.json
+++ b/packages/@react-ui/tsconfig.json
@@ -6,7 +6,7 @@
     "rootDir": "./src",
     "jsx": "react-jsx",
     "declaration": true,
-    "declarationMap": true,
+    "declarationMap": false,
     "sourceMap": true,
     "composite": false,
     "module": "ESNext",

--- a/packages/@react-ui/tsconfig.json
+++ b/packages/@react-ui/tsconfig.json
@@ -6,7 +6,7 @@
     "rootDir": "./src",
     "jsx": "react-jsx",
     "declaration": true,
-    "declarationMap": false,
+    "declarationMap": true,
     "sourceMap": true,
     "composite": false,
     "module": "ESNext",

--- a/packages/@react-ui/tsconfig.json
+++ b/packages/@react-ui/tsconfig.json
@@ -2,19 +2,20 @@
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "baseUrl": ".",
-    "outDir": "dist",
-    "rootDir": "src",
+    "outDir": "./dist",
+    "rootDir": "./src",
     "jsx": "react-jsx",
     "declaration": true,
-    "declarationMap": false,
-    "sourceMap": false,
-    "composite": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "composite": false,
     "module": "ESNext",
-    "moduleResolution": "bundler",
+    "moduleResolution": "node",
     "allowSyntheticDefaultImports": true,
     "esModuleInterop": true,
     "skipLibCheck": true,
-    "strict": true
+    "strict": true,
+    "noEmit": false
   },
   "include": ["src/**/*"],
   "exclude": ["node_modules", "dist", "**/*.stories.tsx", "**/*.test.tsx"]


### PR DESCRIPTION
This pull request introduces several foundational improvements to the `@react-ui` package, preparing it for public distribution and use as a React component library. The changes include adding essential project files, updating configuration for publishing, and improving documentation.

**Project setup and configuration:**

* Added a `.gitignore` file to exclude build outputs, dependencies, IDE files, and OS-specific files from version control, ensuring a cleaner repository.
* Updated `package.json`:
  * Renamed the package to `@gmz/react-ui`, updated versioning, and set up the main/types entry points to use the `dist` directory.
  * Added repository and publish configuration for public npm publishing.
  * Modified the `exports` and `files` fields to ensure only built files and documentation are published.
  * Added build, dev, and clean scripts for easier development and distribution. [[1]](diffhunk://#diff-8ca5f0de272a22da08931f920413d6bf8aa5281450bcd2a66980b1ec244f4192L2-R31) [[2]](diffhunk://#diff-8ca5f0de272a22da08931f920413d6bf8aa5281450bcd2a66980b1ec244f4192L37-R51)

**Build and TypeScript configuration:**

* Updated `tsconfig.json` to output builds to `./dist`, generate declaration/source maps, and use proper module resolution for npm packages.

**Documentation:**

* Added a comprehensive `README.md` describing installation, usage, available components, and licensing for the UI library.