### PR TITLE
V2.2 fix build and naming issues

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -78,3 +78,7 @@ report.[0-9]*.[0-9]*.[0-9]*.[0-9]*.json
 
 # TypeScript
 *.tsbuildinfo
+
+# React UI Package specific
+packages/@react-ui/dist/
+packages/@react-ui/dist-cjs/

--- a/apps/frontend/package.json
+++ b/apps/frontend/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "type": "module",
   "dependencies": {
-    "@react-ui": "workspace:*",
+    "@gmz/react-ui": "workspace:*",
     "@tanstack/react-query": "^5.77.2",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",

--- a/apps/frontend/src/App.tsx
+++ b/apps/frontend/src/App.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Routes, Route } from 'react-router-dom';
 
-import { ThemeProvider } from '@react-ui';
+import { ThemeProvider } from '@gmz/react-ui';
 import { LandingPage } from './pages/LandingPage';
 import ProfilePage from './pages/ProfilePage';
 

--- a/apps/frontend/src/components/auth/GoogleLoginButton.tsx
+++ b/apps/frontend/src/components/auth/GoogleLoginButton.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 import googleIcon from '../../assets/icons/google-icon.png';
 import { environment } from '../../config/environments';
-import { Button } from '@react-ui';
+import { Button } from '@gmz/react-ui';
 
 export const GoogleLoginButton: React.FC = () => {
   const { backendUrl } = environment.app;

--- a/apps/frontend/src/pages/ChatInterface.tsx
+++ b/apps/frontend/src/pages/ChatInterface.tsx
@@ -7,7 +7,7 @@ import { v4 as uuidv4 } from 'uuid';
 import { apiClient } from '../api/api';
 import { chatMessagesState, userProfileState } from '../recoil/Object.recoil';
 import { ChatMessage } from '../types/types';
-import { Box, Button, Flex, Typography } from '@react-ui';
+import { Box, Button, Flex, Typography } from '@gmz/react-ui';
 
 const ChatInterface: React.FC = () => {
   const [inputValue, setInputValue] = useState('');

--- a/apps/frontend/src/pages/LandingPage.tsx
+++ b/apps/frontend/src/pages/LandingPage.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 
 import { apiClient } from '../api/api';
 import { GoogleLoginButton } from '../components/auth/GoogleLoginButton';
-import { Flex, Typography } from '@react-ui';
+import { Flex, Typography } from '@gmz/react-ui';
 
 export const LandingPage: React.FC = () => {
   const { error: pingError } = useQuery({

--- a/apps/frontend/src/pages/ProfilePage.tsx
+++ b/apps/frontend/src/pages/ProfilePage.tsx
@@ -6,7 +6,7 @@ import profileImage from '../assets/images/profile-img.png';
 import { userProfileState } from '../recoil/Object.recoil';
 import { useUserState } from '../utils/userHelpers';
 import ChatInterface from './ChatInterface';
-import { Box, Flex, Typography } from '@react-ui';
+import { Box, Flex, Typography } from '@gmz/react-ui';
 
 const ProfilePage: React.FC = () => {
   const { error, isLoading } = useUserState();

--- a/apps/frontend/tsconfig.json
+++ b/apps/frontend/tsconfig.json
@@ -6,7 +6,7 @@
     "lib": ["ES2020", "DOM", "DOM.Iterable"],
     "module": "ESNext",
     "skipLibCheck": true,
-    "moduleResolution": "bundler",
+    "moduleResolution": "node",
     "allowSyntheticDefaultImports": true,
     "resolveJsonModule": true,
     "isolatedModules": true,
@@ -29,7 +29,7 @@
 
     "paths": {
       "@frontend/*": ["./src/*"],
-      "@react-ui/*": ["../../packages/@react-ui/src/*"]
+      "@gmz/react-ui/*": ["../../packages/@react-ui/src/*"]
     }
   },
   "include": [

--- a/apps/storybook-react-ui/package.json
+++ b/apps/storybook-react-ui/package.json
@@ -10,7 +10,7 @@
     "clean": "rm -rf storybook-static dist .turbo"
   },
   "dependencies": {
-    "@react-ui": "workspace:*",
+    "@gmz/react-ui": "workspace:*",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   },

--- a/apps/storybook-react-ui/tsconfig.json
+++ b/apps/storybook-react-ui/tsconfig.json
@@ -3,7 +3,7 @@
   "compilerOptions": {
     "baseUrl": ".",
     "paths": {
-      "@react-ui/*": ["../../packages/@react-ui/src/*"]
+      "@gmz/react-ui/*": ["../../packages/@react-ui/src/*"]
     },
     "jsx": "react-jsx",
     "lib": ["DOM", "DOM.Iterable", "ESNext"],

--- a/packages/@react-ui/src/lib/components/Typography/Typography.tsx
+++ b/packages/@react-ui/src/lib/components/Typography/Typography.tsx
@@ -3,7 +3,7 @@
 import React, { forwardRef } from 'react';
 import { type VariantProps } from 'class-variance-authority';
 import { cn } from '../../tools/classNames';
-import { typographyVariants, variantElementMap, type TypographyVariant } from './typography.config';
+import { typographyVariants, variantElementMap } from './typography.config';
 
 /**
  * Typography Component

--- a/packages/@react-ui/src/lib/system/ThemeProvider.tsx
+++ b/packages/@react-ui/src/lib/system/ThemeProvider.tsx
@@ -1,7 +1,6 @@
 // packages/ui/src/lib/system/ThemeProvider.tsx
 
 import React, { createContext, useContext, useEffect, useState } from 'react';
-import './globals.css';
 
 // Theme configuration (moved to TypeScript for JS access)
 export const themeConfig = {

--- a/packages/@react-ui/tsconfig.cjs.json
+++ b/packages/@react-ui/tsconfig.cjs.json
@@ -3,6 +3,7 @@
   "compilerOptions": {
     "module": "CommonJS",
     "outDir": "./dist-cjs",
-    "declaration": false
+    "declaration": false,
+    "declarationMap": false
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -180,7 +180,7 @@ importers:
 
   apps/frontend:
     dependencies:
-      '@react-ui':
+      '@gmz/react-ui':
         specifier: workspace:*
         version: link:../../packages/@react-ui
       '@tanstack/react-query':
@@ -301,7 +301,7 @@ importers:
 
   apps/storybook-react-ui:
     dependencies:
-      '@react-ui':
+      '@gmz/react-ui':
         specifier: workspace:*
         version: link:../../packages/@react-ui
       react:

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -10,8 +10,8 @@
     "jsx": "react-jsx",
     "baseUrl": ".",
     "paths": {
-      "@react-ui": ["packages/@react-ui/src/index.ts"],
-      "@react-ui/*": ["packages/@react-ui/src/*"]
+      "@gmz/react-ui": ["packages/@react-ui/src/index.ts"],
+      "@gmz/react-ui/*": ["packages/@react-ui/src/*"]
     }
   }
 }


### PR DESCRIPTION
This pull request updates the project to use the new `@gmz/react-ui` package name instead of `@react-ui` throughout the codebase, configuration files, and dependencies. Additionally, it adjusts TypeScript configuration for module resolution and declaration maps, and makes a minor cleanup in the UI package.

**Package renaming and import updates:**

* Updated all imports in the frontend app and Storybook to use `@gmz/react-ui` instead of `@react-ui` in source files such as `App.tsx`, `GoogleLoginButton.tsx`, `ChatInterface.tsx`, `LandingPage.tsx`, and `ProfilePage.tsx` [[1]](diffhunk://#diff-8e26884a60b9c68df86a8f3b810eeb027a5d5424fdea2ae3df725c19fb8376e6L4-R4) [[2]](diffhunk://#diff-c6abc58a94e30694b985b1ba7b59f1e5a898e8dc030f9ca55df381cbeb30518eL5-R5) [[3]](diffhunk://#diff-0653d810be62ac8bee06223b51d53f848c6f9f506d71e52502c0cd8e46e72834L10-R10) [[4]](diffhunk://#diff-cd0963b26e4eb52a13684570f451f3739771701611a4b4e3afc2c3b3e588a558L6-R6) [[5]](diffhunk://#diff-8716589cd86a1e3e43409bbed0328dee5a26e45943806d4af4ea51df08bcb347L9-R9).
* Changed package dependencies in `package.json` files for both frontend and Storybook apps to reference `@gmz/react-ui` [[1]](diffhunk://#diff-7a5fd52fecdd7d9318307d2bc348b2f3c7977dbec5fa49a9bacaaaf632737cf6L7-R7) [[2]](diffhunk://#diff-9f1836886c0f5b5790ed5e441a5f4f39c64bc240347f8d2746fb3616f6ad4214L13-R13).
* Updated import paths in TypeScript config files (`tsconfig.json`, `tsconfig.base.json`) and lockfiles to use the new package name [[1]](diffhunk://#diff-2759950f9722e3b68555cdaf7a69df1d663b85aa5252a8335ff4fc1aa8f4fe18L32-R32) [[2]](diffhunk://#diff-75b7131940426e9e047905cd6ad1133749c048ecd348b2137e04ad56a5d81470L6-R6) [[3]](diffhunk://#diff-0b280a445be167f54cd916c0718c952b8e0d4ca9621903d05eec25efd4c6ed6dL13-R14) [[4]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL183-R183) [[5]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL304-R304).

**TypeScript and build configuration:**

* Changed `moduleResolution` from `bundler` to `node` in the frontend TypeScript config for better compatibility.
* Disabled generation of declaration maps in the CommonJS build config for the UI package.

**Minor code cleanup:**

* Removed an unused import (`TypographyVariant`) from the `Typography.tsx` component.
* Removed a global CSS import from the `ThemeProvider.tsx` file, likely to avoid duplicate or unwanted global styles.