### PR TITLE
v2.1.3 refactor: update naming to match scope

### DIFF
--- a/apps/frontend/package.json
+++ b/apps/frontend/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "type": "module",
   "dependencies": {
-    "@gmz/react-ui": "workspace:*",
+    "@gmzh/react-ui": "workspace:*",
     "@tanstack/react-query": "^5.77.2",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",

--- a/apps/frontend/src/App.tsx
+++ b/apps/frontend/src/App.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Routes, Route } from 'react-router-dom';
 
-import { ThemeProvider } from '@gmz/react-ui';
+import { ThemeProvider } from '@gmzh/react-ui';
 import { LandingPage } from './pages/LandingPage';
 import ProfilePage from './pages/ProfilePage';
 

--- a/apps/frontend/src/components/auth/GoogleLoginButton.tsx
+++ b/apps/frontend/src/components/auth/GoogleLoginButton.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 import googleIcon from '../../assets/icons/google-icon.png';
 import { environment } from '../../config/environments';
-import { Button } from '@gmz/react-ui';
+import { Button } from '@gmzh/react-ui';
 
 export const GoogleLoginButton: React.FC = () => {
   const { backendUrl } = environment.app;

--- a/apps/frontend/src/pages/ChatInterface.tsx
+++ b/apps/frontend/src/pages/ChatInterface.tsx
@@ -7,7 +7,7 @@ import { v4 as uuidv4 } from 'uuid';
 import { apiClient } from '../api/api';
 import { chatMessagesState, userProfileState } from '../recoil/Object.recoil';
 import { ChatMessage } from '../types/types';
-import { Box, Button, Flex, Typography } from '@gmz/react-ui';
+import { Box, Button, Flex, Typography } from '@gmzh/react-ui';
 
 const ChatInterface: React.FC = () => {
   const [inputValue, setInputValue] = useState('');

--- a/apps/frontend/src/pages/LandingPage.tsx
+++ b/apps/frontend/src/pages/LandingPage.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 
 import { apiClient } from '../api/api';
 import { GoogleLoginButton } from '../components/auth/GoogleLoginButton';
-import { Flex, Typography } from '@gmz/react-ui';
+import { Flex, Typography } from '@gmzh/react-ui';
 
 export const LandingPage: React.FC = () => {
   const { error: pingError } = useQuery({

--- a/apps/frontend/src/pages/ProfilePage.tsx
+++ b/apps/frontend/src/pages/ProfilePage.tsx
@@ -6,7 +6,7 @@ import profileImage from '../assets/images/profile-img.png';
 import { userProfileState } from '../recoil/Object.recoil';
 import { useUserState } from '../utils/userHelpers';
 import ChatInterface from './ChatInterface';
-import { Box, Flex, Typography } from '@gmz/react-ui';
+import { Box, Flex, Typography } from '@gmzh/react-ui';
 
 const ProfilePage: React.FC = () => {
   const { error, isLoading } = useUserState();

--- a/apps/frontend/tsconfig.json
+++ b/apps/frontend/tsconfig.json
@@ -29,7 +29,7 @@
 
     "paths": {
       "@frontend/*": ["./src/*"],
-      "@gmz/react-ui/*": ["../../packages/@react-ui/src/*"]
+      "@gmzh/react-ui/*": ["../../packages/@react-ui/src/*"]
     }
   },
   "include": [

--- a/apps/storybook-react-ui/package.json
+++ b/apps/storybook-react-ui/package.json
@@ -10,7 +10,7 @@
     "clean": "rm -rf storybook-static dist .turbo"
   },
   "dependencies": {
-    "@gmz/react-ui": "workspace:*",
+    "@gmzh/react-ui": "workspace:*",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   },

--- a/apps/storybook-react-ui/tsconfig.json
+++ b/apps/storybook-react-ui/tsconfig.json
@@ -3,7 +3,7 @@
   "compilerOptions": {
     "baseUrl": ".",
     "paths": {
-      "@gmz/react-ui/*": ["../../packages/@react-ui/src/*"]
+      "@gmzh/react-ui/*": ["../../packages/@react-ui/src/*"]
     },
     "jsx": "react-jsx",
     "lib": ["DOM", "DOM.Iterable", "ESNext"],

--- a/packages/@react-ui/README.md
+++ b/packages/@react-ui/README.md
@@ -1,17 +1,17 @@
-# @gmz/react-ui
+# @gmzh/react-ui
 
 A React UI component library built with TypeScript and Tailwind CSS.
 
 ## Installation
 
 ```bash
-npm install @gmz/react-ui
+npm install @gmzh/react-ui
 ```
 
 ## Usage
 
 ```tsx
-import { Button, Alert, Badge, Box } from '@gmz/react-ui';
+import { Button, Alert, Badge, Box } from '@gmzh/react-ui';
 
 function App() {
   return (

--- a/packages/@react-ui/package.json
+++ b/packages/@react-ui/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@gmz/react-ui",
+  "name": "@gmzh/react-ui",
   "version": "0.1.0",
   "main": "./dist/index.cjs",
   "module": "./dist/index.js",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,7 +10,7 @@ importers:
     devDependencies:
       '@storybook/addon-essentials':
         specifier: ^8.6.14
-        version: 8.6.14(@types/react@18.3.23)(storybook@8.6.14(prettier@3.0.0))
+        version: 8.6.14(@types/react@18.3.21)(storybook@8.6.14(prettier@3.0.0))
       '@storybook/addon-interactions':
         specifier: ^8.6.14
         version: 8.6.14(storybook@8.6.14(prettier@3.0.0))
@@ -128,7 +128,7 @@ importers:
     devDependencies:
       '@nestjs/cli':
         specifier: ^10.0.0
-        version: 10.4.9(esbuild@0.25.4)
+        version: 10.4.9
       '@nestjs/schematics':
         specifier: ^10.0.0
         version: 10.2.3(chokidar@3.6.0)(typescript@5.8.3)
@@ -164,10 +164,10 @@ importers:
         version: 7.1.1
       ts-jest:
         specifier: ^29.1.0
-        version: 29.3.2(@babel/core@7.27.1)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.27.1))(esbuild@0.25.4)(jest@29.7.0(@types/node@20.17.46)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@20.17.46)(typescript@5.8.3)))(typescript@5.8.3)
+        version: 29.3.2(@babel/core@7.27.1)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.27.1))(jest@29.7.0(@types/node@20.17.46)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@20.17.46)(typescript@5.8.3)))(typescript@5.8.3)
       ts-loader:
         specifier: ^9.4.3
-        version: 9.5.2(typescript@5.8.3)(webpack@5.97.1(esbuild@0.25.4))
+        version: 9.5.2(typescript@5.8.3)(webpack@5.97.1)
       ts-node:
         specifier: ^10.9.1
         version: 10.9.2(@types/node@20.17.46)(typescript@5.8.3)
@@ -180,7 +180,7 @@ importers:
 
   apps/frontend:
     dependencies:
-      '@gmz/react-ui':
+      '@gmzh/react-ui':
         specifier: workspace:*
         version: link:../../packages/@react-ui
       '@tanstack/react-query':
@@ -301,7 +301,7 @@ importers:
 
   apps/storybook-react-ui:
     dependencies:
-      '@gmz/react-ui':
+      '@gmzh/react-ui':
         specifier: workspace:*
         version: link:../../packages/@react-ui
       react:
@@ -7370,12 +7370,6 @@ snapshots:
       '@types/react': 18.3.21
       react: 18.3.1
 
-  '@mdx-js/react@3.1.0(@types/react@18.3.23)(react@18.3.1)':
-    dependencies:
-      '@types/mdx': 2.0.13
-      '@types/react': 18.3.23
-      react: 18.3.1
-
   '@napi-rs/wasm-runtime@0.2.10':
     dependencies:
       '@emnapi/core': 1.4.3
@@ -7383,7 +7377,7 @@ snapshots:
       '@tybys/wasm-util': 0.9.0
     optional: true
 
-  '@nestjs/cli@10.4.9(esbuild@0.25.4)':
+  '@nestjs/cli@10.4.9':
     dependencies:
       '@angular-devkit/core': 17.3.11(chokidar@3.6.0)
       '@angular-devkit/schematics': 17.3.11(chokidar@3.6.0)
@@ -7393,7 +7387,7 @@ snapshots:
       chokidar: 3.6.0
       cli-table3: 0.6.5
       commander: 4.1.1
-      fork-ts-checker-webpack-plugin: 9.0.2(typescript@5.7.2)(webpack@5.97.1(esbuild@0.25.4))
+      fork-ts-checker-webpack-plugin: 9.0.2(typescript@5.7.2)(webpack@5.97.1)
       glob: 10.4.5
       inquirer: 8.2.6
       node-emoji: 1.11.0
@@ -7402,7 +7396,7 @@ snapshots:
       tsconfig-paths: 4.2.0
       tsconfig-paths-webpack-plugin: 4.2.0
       typescript: 5.7.2
-      webpack: 5.97.1(esbuild@0.25.4)
+      webpack: 5.97.1
       webpack-node-externals: 3.0.0
     transitivePeerDependencies:
       - esbuild
@@ -7922,41 +7916,12 @@ snapshots:
     transitivePeerDependencies:
       - '@types/react'
 
-  '@storybook/addon-docs@8.6.14(@types/react@18.3.23)(storybook@8.6.14(prettier@3.0.0))':
-    dependencies:
-      '@mdx-js/react': 3.1.0(@types/react@18.3.23)(react@18.3.1)
-      '@storybook/blocks': 8.6.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.6.14(prettier@3.0.0))
-      '@storybook/csf-plugin': 8.6.14(storybook@8.6.14(prettier@3.0.0))
-      '@storybook/react-dom-shim': 8.6.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.6.14(prettier@3.0.0))
-      react: 18.3.1
-      react-dom: 18.3.1(react@18.3.1)
-      storybook: 8.6.14(prettier@3.0.0)
-      ts-dedent: 2.2.0
-    transitivePeerDependencies:
-      - '@types/react'
-
   '@storybook/addon-essentials@8.6.14(@types/react@18.3.21)(storybook@8.6.14(prettier@3.0.0))':
     dependencies:
       '@storybook/addon-actions': 8.6.14(storybook@8.6.14(prettier@3.0.0))
       '@storybook/addon-backgrounds': 8.6.14(storybook@8.6.14(prettier@3.0.0))
       '@storybook/addon-controls': 8.6.14(storybook@8.6.14(prettier@3.0.0))
       '@storybook/addon-docs': 8.6.14(@types/react@18.3.21)(storybook@8.6.14(prettier@3.0.0))
-      '@storybook/addon-highlight': 8.6.14(storybook@8.6.14(prettier@3.0.0))
-      '@storybook/addon-measure': 8.6.14(storybook@8.6.14(prettier@3.0.0))
-      '@storybook/addon-outline': 8.6.14(storybook@8.6.14(prettier@3.0.0))
-      '@storybook/addon-toolbars': 8.6.14(storybook@8.6.14(prettier@3.0.0))
-      '@storybook/addon-viewport': 8.6.14(storybook@8.6.14(prettier@3.0.0))
-      storybook: 8.6.14(prettier@3.0.0)
-      ts-dedent: 2.2.0
-    transitivePeerDependencies:
-      - '@types/react'
-
-  '@storybook/addon-essentials@8.6.14(@types/react@18.3.23)(storybook@8.6.14(prettier@3.0.0))':
-    dependencies:
-      '@storybook/addon-actions': 8.6.14(storybook@8.6.14(prettier@3.0.0))
-      '@storybook/addon-backgrounds': 8.6.14(storybook@8.6.14(prettier@3.0.0))
-      '@storybook/addon-controls': 8.6.14(storybook@8.6.14(prettier@3.0.0))
-      '@storybook/addon-docs': 8.6.14(@types/react@18.3.23)(storybook@8.6.14(prettier@3.0.0))
       '@storybook/addon-highlight': 8.6.14(storybook@8.6.14(prettier@3.0.0))
       '@storybook/addon-measure': 8.6.14(storybook@8.6.14(prettier@3.0.0))
       '@storybook/addon-outline': 8.6.14(storybook@8.6.14(prettier@3.0.0))
@@ -10355,7 +10320,7 @@ snapshots:
       cross-spawn: 7.0.6
       signal-exit: 4.1.0
 
-  fork-ts-checker-webpack-plugin@9.0.2(typescript@5.7.2)(webpack@5.97.1(esbuild@0.25.4)):
+  fork-ts-checker-webpack-plugin@9.0.2(typescript@5.7.2)(webpack@5.97.1):
     dependencies:
       '@babel/code-frame': 7.27.1
       chalk: 4.1.2
@@ -10370,7 +10335,7 @@ snapshots:
       semver: 7.7.2
       tapable: 2.2.1
       typescript: 5.7.2
-      webpack: 5.97.1(esbuild@0.25.4)
+      webpack: 5.97.1
 
   form-data-encoder@1.7.2: {}
 
@@ -12816,16 +12781,14 @@ snapshots:
 
   tapable@2.2.1: {}
 
-  terser-webpack-plugin@5.3.14(esbuild@0.25.4)(webpack@5.97.1(esbuild@0.25.4)):
+  terser-webpack-plugin@5.3.14(webpack@5.97.1):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.25
       jest-worker: 27.5.1
       schema-utils: 4.3.2
       serialize-javascript: 6.0.2
       terser: 5.39.1
-      webpack: 5.97.1(esbuild@0.25.4)
-    optionalDependencies:
-      esbuild: 0.25.4
+      webpack: 5.97.1
 
   terser@5.39.1:
     dependencies:
@@ -12915,7 +12878,7 @@ snapshots:
 
   ts-interface-checker@0.1.13: {}
 
-  ts-jest@29.3.2(@babel/core@7.27.1)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.27.1))(esbuild@0.25.4)(jest@29.7.0(@types/node@20.17.46)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@20.17.46)(typescript@5.8.3)))(typescript@5.8.3):
+  ts-jest@29.3.2(@babel/core@7.27.1)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.27.1))(jest@29.7.0(@types/node@20.17.46)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@20.17.46)(typescript@5.8.3)))(typescript@5.8.3):
     dependencies:
       bs-logger: 0.2.6
       ejs: 3.1.10
@@ -12934,9 +12897,8 @@ snapshots:
       '@jest/transform': 29.7.0
       '@jest/types': 29.6.3
       babel-jest: 29.7.0(@babel/core@7.27.1)
-      esbuild: 0.25.4
 
-  ts-loader@9.5.2(typescript@5.8.3)(webpack@5.97.1(esbuild@0.25.4)):
+  ts-loader@9.5.2(typescript@5.8.3)(webpack@5.97.1):
     dependencies:
       chalk: 4.1.2
       enhanced-resolve: 5.18.1
@@ -12944,7 +12906,7 @@ snapshots:
       semver: 7.7.2
       source-map: 0.7.4
       typescript: 5.8.3
-      webpack: 5.97.1(esbuild@0.25.4)
+      webpack: 5.97.1
 
   ts-node@10.9.2(@types/node@20.17.46)(typescript@5.8.3):
     dependencies:
@@ -13389,7 +13351,7 @@ snapshots:
 
   webpack-virtual-modules@0.6.2: {}
 
-  webpack@5.97.1(esbuild@0.25.4):
+  webpack@5.97.1:
     dependencies:
       '@types/eslint-scope': 3.7.7
       '@types/estree': 1.0.7
@@ -13411,7 +13373,7 @@ snapshots:
       neo-async: 2.6.2
       schema-utils: 3.3.0
       tapable: 2.2.1
-      terser-webpack-plugin: 5.3.14(esbuild@0.25.4)(webpack@5.97.1(esbuild@0.25.4))
+      terser-webpack-plugin: 5.3.14(webpack@5.97.1)
       watchpack: 2.4.2
       webpack-sources: 3.2.3
     transitivePeerDependencies:

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -10,8 +10,8 @@
     "jsx": "react-jsx",
     "baseUrl": ".",
     "paths": {
-      "@gmz/react-ui": ["packages/@react-ui/src/index.ts"],
-      "@gmz/react-ui/*": ["packages/@react-ui/src/*"]
+      "@gmzh/react-ui": ["packages/@react-ui/src/index.ts"],
+      "@gmzh/react-ui/*": ["packages/@react-ui/src/*"]
     }
   }
 }


### PR DESCRIPTION
This pull request renames the `@gmz/react-ui` package to `@gmzh/react-ui` throughout the codebase. The change affects all relevant import paths, package names, documentation, and configuration files to ensure consistency and prevent module resolution issues. Additionally, some dependency lockfile entries are updated, mainly to remove unnecessary peer dependencies and clean up references.

**Package rename and import path updates:**

* Renamed the package in all `package.json` files and updated all imports from `@gmz/react-ui` to `@gmzh/react-ui` in the frontend app and Storybook (`apps/frontend/package.json`, `apps/storybook-react-ui/package.json`, `packages/@react-ui/package.json`, [[1]](diffhunk://#diff-7a5fd52fecdd7d9318307d2bc348b2f3c7977dbec5fa49a9bacaaaf632737cf6L7-R7) [[2]](diffhunk://#diff-9f1836886c0f5b5790ed5e441a5f4f39c64bc240347f8d2746fb3616f6ad4214L13-R13) [[3]](diffhunk://#diff-8ca5f0de272a22da08931f920413d6bf8aa5281450bcd2a66980b1ec244f4192L2-R2).
* Updated all TypeScript import statements in frontend source files to use `@gmzh/react-ui` (`App.tsx`, `GoogleLoginButton.tsx`, `ChatInterface.tsx`, `LandingPage.tsx`, `ProfilePage.tsx`, [[1]](diffhunk://#diff-8e26884a60b9c68df86a8f3b810eeb027a5d5424fdea2ae3df725c19fb8376e6L4-R4) [[2]](diffhunk://#diff-c6abc58a94e30694b985b1ba7b59f1e5a898e8dc030f9ca55df381cbeb30518eL5-R5) [[3]](diffhunk://#diff-0653d810be62ac8bee06223b51d53f848c6f9f506d71e52502c0cd8e46e72834L10-R10) [[4]](diffhunk://#diff-cd0963b26e4eb52a13684570f451f3739771701611a4b4e3afc2c3b3e588a558L6-R6) [[5]](diffhunk://#diff-8716589cd86a1e3e43409bbed0328dee5a26e45943806d4af4ea51df08bcb347L9-R9).
* Changed all relevant `tsconfig.json` and `tsconfig.base.json` path aliases from `@gmz/react-ui` to `@gmzh/react-ui` to match the new package name (`apps/frontend/tsconfig.json`, `apps/storybook-react-ui/tsconfig.json`, `tsconfig.base.json`, [[1]](diffhunk://#diff-2759950f9722e3b68555cdaf7a69df1d663b85aa5252a8335ff4fc1aa8f4fe18L32-R32) [[2]](diffhunk://#diff-75b7131940426e9e047905cd6ad1133749c048ecd348b2137e04ad56a5d81470L6-R6) [[3]](diffhunk://#diff-0b280a445be167f54cd916c0718c952b8e0d4ca9621903d05eec25efd4c6ed6dL13-R14).
* Updated the package name and usage instructions in the `@react-ui` README (`packages/@react-ui/README.md`, [packages/@react-ui/README.mdL1-R14](diffhunk://#diff-77bce4c12668da0b67ae6988d05e3bf6a0cc4126d63583f2d99976f7bea3cefaL1-R14)).

**Dependency and lockfile cleanup:**

* Updated `pnpm-lock.yaml` to reflect the new package name and cleaned up several dependency references, removing unnecessary peer dependencies and optional dependencies related to `esbuild` (`pnpm-lock.yaml`, [[1]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL13-R13) [[2]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL131-R131) [[3]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL167-R170) [[4]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL183-R183) [[5]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL304-R304) [[6]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL7373-R7380) [[7]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL7396-R7390) [[8]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL7405-R7399) [[9]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL7925-L7937) [[10]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL7954-L7969) [[11]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL10358-R10323) [[12]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL10373-R10338) [[13]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL12819-R12791) [[14]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL12918-R12881) [[15]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL12937-R12909) [[16]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL13392-R13354) [[17]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL13414-R13376).

This ensures all projects are using the correct, unified package name and avoids any confusion or build errors due to mismatched imports or dependencies.